### PR TITLE
Add settings option to specify mermaid version

### DIFF
--- a/inc/admin/register.php
+++ b/inc/admin/register.php
@@ -32,7 +32,7 @@ function wp_mermaid_uninstall() {
 
 	if ( 'yes' === $option_uninstall ) {
 		delete_option( 'wp_mermaid_js_source' );
-		delete_option( 'wp_mermaid_js_versionF' );
+		delete_option( 'wp_mermaid_js_version' );
 		delete_option( 'wp_mermaid_uninstall_option' );
 	}
 }

--- a/inc/admin/register.php
+++ b/inc/admin/register.php
@@ -18,6 +18,7 @@ register_uninstall_hook( __FILE__, 'wp_mermaid_uninstall' );
  */
 function wp_mermaid_activation() {
 	add_option( 'wp_mermaid_js_source', 'local' );
+	add_option( 'wp_mermaid_js_version', MERMAID_JS_VERSION );
 	add_option( 'wp_mermaid_uninstall_option', 'yes' );
 }
 
@@ -31,6 +32,7 @@ function wp_mermaid_uninstall() {
 
 	if ( 'yes' === $option_uninstall ) {
 		delete_option( 'wp_mermaid_js_source' );
+		delete_option( 'wp_mermaid_js_versionF' );
 		delete_option( 'wp_mermaid_uninstall_option' );
 	}
 }

--- a/inc/admin/setting.php
+++ b/inc/admin/setting.php
@@ -77,7 +77,7 @@ function wp_mermaid_js_source_callback() {
 				<label for="wp-mermaid-js-library-source-2">
 					<?php echo __( 'cdn.cloudflare.com', 'wp-mermaid' ); ?>
 				<label>
-			
+
 			</div>
 			<div>
 				<input type="radio" name="wp_mermaid_js_source" id="wp-mermaid-js-library-source-2" <?php checked( $option_js_source, 'jsdelivr' ); ?> value="jsdelivr">
@@ -96,15 +96,26 @@ function wp_mermaid_js_source_callback() {
  *
  * @return void
  */
-function wp_mermaid_js_version_callback() {
-	?>
-		<div>
-			<div>
-				<input type="input" name="wp_mermaid_js_version" id="wp-mermaid-js-library-version" value="<?php echo get_option( 'wp_mermaid_js_version', MERMAID_JS_VERSION ); ?>" />
-			</div>
-		</div>
-		<p><em><?php echo __( 'Version of the Mermaid library to use from a CDN service. Warning: Correct version of the library is not validated! Use at your own risk.', 'wp-mermaid' ); ?></em></p>
-	<?php
+function wp_mermaid_js_version_callback()
+{
+    ?>
+    <div>
+        <div>
+            <input type="input" size="6" name="wp_mermaid_js_version" id="wp-mermaid-js-library-version"
+                   value="<?php echo get_option('wp_mermaid_js_version', MERMAID_JS_VERSION); ?>"/>
+        </div>
+    </div>
+    <p><em><?php echo __('Version of the Mermaid library to use from a CDN service.', 'wp-mermaid'); ?></em></p>
+    <p>
+        <em>
+            <b><?php echo __('Warning', 'wp-mermaid'); ?>: </b>
+            <?php echo __('Correct version of the library is not validated! Use at your own risk.', 'wp-mermaid'); ?>
+            <?php echo __('See', 'wp-mermaid'); ?> <a href="https://github.com/mermaid-js/mermaid/tags">
+                <?php echo __('available versions', 'wp-mermaid'); ?>
+            </a>.
+        </em>
+    </p>
+    <?php
 }
 
 
@@ -118,19 +129,19 @@ function wp_mermaid_uninstall_option_callback() {
 	?>
 		<div>
 			<div>
-				<input type="radio" name="wp_mermaid_uninstall_option" id="wp-mermaid-uninstall-option-yes" value="yes" 
+				<input type="radio" name="wp_mermaid_uninstall_option" id="wp-mermaid-uninstall-option-yes" value="yes"
 					<?php checked( $option_uninstall_option, 'yes' ); ?>>
 				<label for="wp-mermaid-uninstall-option-yes">
 					<?php echo __( 'Remove WP-Mermaid generated data.', 'wp-mermaid' ); ?><br />
 				<label>
 			</div>
 			<div>
-				<input type="radio" name="wp_mermaid_uninstall_option" id="wp-mermaid-uninstall-option-yes" value="no" 
+				<input type="radio" name="wp_mermaid_uninstall_option" id="wp-mermaid-uninstall-option-yes" value="no"
 					<?php checked( $option_uninstall_option, 'no' ); ?>>
 				<label for="wp-mermaid-uninstall-option-yes">
 					<?php echo __( 'Keep WP-Mermaid generated data.', 'wp-mermaid' ); ?>
 				<label>
-			</div>	
+			</div>
 		</div>
 		<p><em><?php echo __( 'This option only works when you uninstall this plugin.', 'wp-mermaid' ); ?></em></p>
 	<?php

--- a/inc/admin/setting.php
+++ b/inc/admin/setting.php
@@ -18,6 +18,7 @@ add_action( 'admin_init', 'wp_mermaid_settings' );
 function wp_mermaid_settings() {
 
 	register_setting( 'wp_mermaid_setting_group', 'wp_mermaid_js_source' );
+    register_setting( 'wp_mermaid_setting_group', 'wp_mermaid_js_version' );
 	register_setting( 'wp_mermaid_setting_group', 'wp_mermaid_uninstall_option' );
 
 	add_settings_section(

--- a/inc/admin/setting.php
+++ b/inc/admin/setting.php
@@ -36,6 +36,14 @@ function wp_mermaid_settings() {
 	);
 
 	add_settings_field(
+		'wp_mermaid_js_version',
+		__( 'Mermaid Version', 'wp-mermaid' ),
+		'wp_mermaid_js_version_callback',
+		'wp_mermaid_setting_group',
+		'wp_mermaid_basic_section_id'
+	);
+
+	add_settings_field(
 		'wp_mermaid_uninstall_option',
 		__( 'Uninstall Option', 'wp-mermaid' ),
 		'wp_mermaid_uninstall_option_callback',
@@ -78,6 +86,23 @@ function wp_mermaid_js_source_callback() {
 			</div>
 		</div>
 		<p><em><?php echo __( 'This plugin loads mermaid.js locally by default, but if you would like to use it with a CDN service, here is the option.', 'wp-mermaid' ); ?></em></p>
+	<?php
+}
+
+
+/**
+ * Setting block - The Mermaid library version to use from CDNs
+ *
+ * @return void
+ */
+function wp_mermaid_js_version_callback() {
+	?>
+		<div>
+			<div>
+				<input type="input" name="wp_mermaid_js_version" id="wp-mermaid-js-library-version" value="<?php get_option( 'wp_mermaid_js_version', MERMAID_JS_VERSION ); ?>" />
+			</div>
+		</div>
+		<p><em><?php echo __( 'Version of the Mermaid library to use from a CDN service. Warning: Correct version of the library is not validated! Use at your own risk.', 'wp-mermaid' ); ?></em></p>
 	<?php
 }
 

--- a/inc/admin/setting.php
+++ b/inc/admin/setting.php
@@ -100,7 +100,7 @@ function wp_mermaid_js_version_callback() {
 	?>
 		<div>
 			<div>
-				<input type="input" name="wp_mermaid_js_version" id="wp-mermaid-js-library-version" value="<?php get_option( 'wp_mermaid_js_version', MERMAID_JS_VERSION ); ?>" />
+				<input type="input" name="wp_mermaid_js_version" id="wp-mermaid-js-library-version" value="<?php echo get_option( 'wp_mermaid_js_version', MERMAID_JS_VERSION ); ?>" />
 			</div>
 		</div>
 		<p><em><?php echo __( 'Version of the Mermaid library to use from a CDN service. Warning: Correct version of the library is not validated! Use at your own risk.', 'wp-mermaid' ); ?></em></p>

--- a/inc/mermaid-js.php
+++ b/inc/mermaid-js.php
@@ -39,14 +39,15 @@ function wp_mermaid_enqueue_scripts() {
 	if ( $load_mermaid_js ) {
 
 		$option = get_option( 'wp_mermaid_js_source' );
+		$version = get_option( 'wp_mermaid_js_version' );
 
 		switch ( $option ) {
 			case 'cloudflare':
-				$script_url = 'https://cdnjs.cloudflare.com/ajax/libs/mermaid/' . MERMAID_JS_VERSION . '/mermaid.min.js';
+				$script_url = 'https://cdnjs.cloudflare.com/ajax/libs/mermaid/' . $version . '/mermaid.min.js';
 				break;
 
 			case 'jsdelivr':
-				$script_url = 'https://cdn.jsdelivr.net/npm/mermaid@' . MERMAID_JS_VERSION . '/dist/mermaid.min.js';
+				$script_url = 'https://cdn.jsdelivr.net/npm/mermaid@' . $version . '/dist/mermaid.min.js';
 				break;
 
 			case 'local':


### PR DESCRIPTION
Hi @terrylinooo. I noticed that the version of mermaid is a bit old. Unfortunately, there is not way to choose the version in the plugin. So I thought rather than having to update the plugin with every version change, it would be better to have the option to choose.

This PR adds a config option to choose the version of the library, defaulting to the embedded one. I went for an input box rather than a drop down, because a list of options would also have to be updated. And at least my intention behind it is to use the latest version, once I tested it works on my site.