### PR TITLE
Fix rendering by using correct top level HTML element

### DIFF
--- a/assets/mermaid/block-editor.js
+++ b/assets/mermaid/block-editor.js
@@ -12,16 +12,16 @@
     blocks.registerBlockType( 'wp-mermaid/block', {
 
 		title: 'WP Mermaid',
-	
+
 		icon: 'chart-pie',
-	
+
 		category: 'formatting',
 
 		attributes: {
 			content: {
 				type: 'string',
 				source: 'text',
-				selector: 'div'
+				selector: 'pre'
 			}
 		},
 
@@ -37,10 +37,10 @@
 					mermaid.init();
 				}, 1000 );
 			}
-			
+
 			try {
 				rendered = '<div class="mermaid">' + "\n" + content + "\n"  + '</div>';
-				
+
 			} catch ( e ) {
 				rendered = `<span style='color: red; text-align: center;'>${e}</span>`;
 			}
@@ -55,24 +55,24 @@
 						'div',
 						{
 							className: 'mermaid-editor'
-						}, 
+						},
 						[
 							wp.element.createElement(
-								wp.editor.PlainText, 
+								wp.editor.PlainText,
 								{
 									onChange: onChangeContent,
 									value: content
-								} 
+								}
 							),
 							wp.element.createElement( 'hr' )
-						] 
+						]
 					),
 					wp.element.createElement(
 						'div',
 						{
 							className: props.className,
 							dangerouslySetInnerHTML: {  __html: rendered }
-						} 
+						}
 					)
 				]
 			);
@@ -82,7 +82,7 @@
 			let content = props.attributes.content;
 
 			return wp.element.createElement(
-				'div',
+				'pre',
 				{
 					className: 'mermaid'
 				},

--- a/inc/mermaid-js.php
+++ b/inc/mermaid-js.php
@@ -10,7 +10,6 @@
 
 add_action( 'loop_end', 'wp_mermaid_enqueue_scripts', 20 );
 add_action( 'admin_enqueue_scripts', 'wp_mermaid_admin_enqueue_scripts' );
-add_action( 'wp_print_footer_scripts', 'wp_mermaid_print_footer_scripts' );
 
 /**
  * Register JS files for backend use.
@@ -56,47 +55,5 @@ function wp_mermaid_enqueue_scripts() {
 		}
 
 		wp_enqueue_script( 'mermaid', $script_url, array(), MERMAID_JS_VERSION, true );
-	}
-}
-
-/**
- * Print JavasSript plaintext in page footer.
- * This method will be called by `wp_print_footer_scripts` hook.
- *
- * @return void
- */
-function wp_mermaid_print_footer_scripts() {
-	global $load_mermaid_js;
-
-	if ( $load_mermaid_js ) {
-
-		$script = '
-			<script id="wp-mermaid">
-
-				( function( $ ) {
-					$( function() {
-						if ( typeof mermaid !== "undefined" ) {
-							let block_count = $( ".mermaid" ).length;
-							let i = 0;
-
-							if ( block_count > 0 ) {
-								$( ".mermaid" ).each( function() {
-									let mermaid_content = $( this ).html();
-									mermaid_content.replace( /<[^>]*>?/gm, "" );
-									$( this ).html( mermaid_content );
-									i++;
-								});
-							}
-
-							if ( block_count === i ) {
-								mermaid.init();
-							}
-						}
-					} );
-				} )( jQuery );
-
-			</script>
-		';
-		echo preg_replace( '/\s+/', ' ', $script );
 	}
 }

--- a/inc/smart-loader.php
+++ b/inc/smart-loader.php
@@ -10,10 +10,6 @@
 
 add_action( 'loop_end', 'wp_mermaid_js_smart_loader', 10 );
 
-// We need to remove `wptexturize` to make the Mermaid syntax work as expected,
-// becuase the HTML encoded characters break the syntax.
-remove_filter( 'the_content', 'wptexturize' );
-
 /**
  * Detect whether Mermaid syntax existed in post content.
  *


### PR DESCRIPTION
Hi @terrylinooo. Thank you for a great plugin! Unfortunately it doesn't render graphs for me due to the issues described in #8. So here's my fix.

According to the [Mermaid documentation](https://mermaid.js.org/intro/getting-started.html#requirements-for-the-mermaid-api), the top level element is supposed to be `<pre>`, not `<div>`

By using `<pre>` as the top level element, some of the workaround code is no longer necessary;
- Turning off `wptexturize`.
- Removing tags in `wp_mermaid_print_footer_scripts` (unless I misunderstood the intention).

I didn't update the release notes. I'll leave that up to @terrylinooo 

Fixes #8